### PR TITLE
feature!: use lazy properties. add or strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.1.12 - 2022-04-26
+
+### Added
+- Strategy concept: inclusive, exclusive, or (considers both sets) 
+- Lazy configuration of properties
+
+### Changed
+- Breaking: Older configurations that did not use defaults have to be updated, see README examples.
+
 ## 0.1.11 - 2022-04-25
 
 ### Fixed

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,7 +41,7 @@ plugins {
 
 ```kotlin
 versionsFilter {
-    exclusiveQualifiers = listOf("rc", "alpha", "beta", "m")
+    exclusiveQualifiers.addAll("rc", "alpha", "beta", "m")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Add an issue if not.
 
 Configurable Options:
 
-Option               | Default                                    | Description
--------------------- | -----------------------------------------  | --------------
-defaultInclusive     | false                                      | default strategy mode - inclusive (true) or exclusive (false)
-inclusiveQualifiers  | "RELEASE","FINAL","GA"                     | default inclusive mode qualifiers 
-exclusiveQualifiers  | "alpha","beta","rc","cr","m","preview","b" | default exclusive mode qualifiers 
-strictSemVer         | false                                       | only show strict SemVer-versions
-log                  | false                                       | verbose debug messages
+| Option              | Default                                    | Description                                      |
+|---------------------|--------------------------------------------|--------------------------------------------------|
+| inclusiveQualifiers | "RELEASE","FINAL","GA"                     | default inclusive mode qualifiers                |
+| exclusiveQualifiers | "alpha","beta","rc","cr","m","preview","b" | default exclusive mode qualifiers                |
+| strategy            | EXCLUSIVE                                  | default strategy mode - EXCLUSIVE, INCLUSIVE, OR |
+| strictSemVer        | false                                      | only show strict SemVer-versions                 |
+| log                 | false                                      | verbose debug messages                           |
 
 In other words, if you do not configure anything, exclude strategy would be used and versions containing "alpha","beta","rc","cr","m","preview","b" would not be considered.
 
@@ -57,14 +57,23 @@ Note: Option values are not case-sensitive
 
 ## Example configuration 
 
-Overriding the defaults, this would show debug output and does NOT exclude "alpha" releases 
 
+### Configuration examples
 
+#### Overriding defaults, this would show debug output and does NOT exclude "alpha" releases
 build.gradle.kts
 ```kotlin
 versionsFilter {
-    exclusiveQualifiers = listOf("beta","rc","cr","m","preview","b" )
-    log = true
+    exclusiveQualifiers.addAll("beta","rc","cr","m","preview","b" )
+    log.set(true)
+}
+```
+
+#### Overriding defaults, this uses inclusive strategy, and does only consider "FINAL" releases
+```kotlin
+versionsFilter {
+    strategy.set(se.ascp.gradle.Strategy.INCLUSIVE)
+    inclusiveQualifiers.addAll("FINAL")
 }
 ```
 ## Example output

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,13 @@
+
 plugins {
-    kotlin("jvm") version "1.6.0" //stick to the supported Gradle plugin version https://docs.gradle.org/current/userguide/compatibility.html
+    kotlin("jvm") version "1.6.0" // stick to the supported Gradle plugin version https://docs.gradle.org/current/userguide/compatibility.html
     id("java-gradle-plugin")
-    id("se.ascp.gradle.gradle-versions-filter") version "0.1.10"
+    id("se.ascp.gradle.gradle-versions-filter") version "0.1.11+"
     id("org.owasp.dependencycheck") version "7.1.0.1"
     id("pl.allegro.tech.build.axion-release") version "1.13.6"
     id("io.gitlab.arturbosch.detekt") version "1.20.0"
     id("se.svt.oss.gradle-yapp-publisher-plugin") version "0.1.15"
+    id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
 }
 
 group = "se.ascp.gradle"
@@ -28,7 +30,7 @@ tasks {
 }
 
 dependencies {
-    implementation("com.github.ben-manes:gradle-versions-plugin:[0.39.0,1.0.0)")
+    implementation("com.github.ben-manes:gradle-versions-plugin:[0.42.0,1.0.0)")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.8.2")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ kotlin.code.style=official
 
 yapp.gradleplugin.id=se.ascp.gradle.gradle-versions-filter
 yapp.gradleplugin.description=Extension of Gradle Versions Plugin (discovering dependency updates) with opinionated defaults
-yapp.gradleplugin.web=https://github.com/jandersson-svt/gradle-versions-filter-plugin
-yapp.gradleplugin.vcs=https://github.com/jandersson-svt/gradle-versions-filter-plugin.git
+yapp.gradleplugin.web=https://github.com/janderssonse/gradle-versions-filter-plugin
+yapp.gradleplugin.vcs=https://github.com/janderssonse/gradle-versions-filter-plugin.git
 yapp.gradleplugin.tags=versions, filter
 yapp.gradleplugin.class=se.ascp.gradle.GradleVersionsFilterPlugin
 yapp.gradleplugin.displayname=Gradle Versions Filter Plugin

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,1 @@
 rootProject.name = "gradle-versions-filter"
-

--- a/src/main/kotlin/se/ascp/gradle/GradleVersionsFilterExtension.kt
+++ b/src/main/kotlin/se/ascp/gradle/GradleVersionsFilterExtension.kt
@@ -4,10 +4,32 @@
 
 package se.ascp.gradle
 
-open class GradleVersionsFilterExtension {
-    var inclusiveQualifiers: List<String> = listOf()
-    var exclusiveQualifiers: List<String> = listOf()
-    var defaultInclusive: Boolean = false
-    var strictSemVer: Boolean = false
-    var log = false
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import javax.inject.Inject
+
+open class GradleVersionsFilterExtension @Inject constructor(objects: ObjectFactory) {
+
+    var inclusiveQualifiers: ListProperty<String> = objects.listProperty(String::class.java).convention(
+        listOf(
+            "RELEASE",
+            "FINAL",
+            "GA"
+        )
+    )
+    var exclusiveQualifiers: ListProperty<String> = objects.listProperty(String::class.java).convention(
+        listOf(
+            "alpha",
+            "beta",
+            "rc",
+            "cr",
+            "m",
+            "preview",
+            "b"
+        )
+    )
+    var strategy: Property<Strategy> = objects.property(Strategy::class.java).convention(Strategy.EXCLUSIVE)
+    var strictSemVer: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+    var log: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 }

--- a/src/main/kotlin/se/ascp/gradle/Strategy.kt
+++ b/src/main/kotlin/se/ascp/gradle/Strategy.kt
@@ -1,0 +1,7 @@
+package se.ascp.gradle
+
+enum class Strategy {
+    INCLUSIVE,
+    EXCLUSIVE,
+    OR;
+}

--- a/src/test/kotlin/se/ascp/gradle/GradleVersionsFilterPluginTest.kt
+++ b/src/test/kotlin/se/ascp/gradle/GradleVersionsFilterPluginTest.kt
@@ -5,19 +5,17 @@
 package se.ascp.gradle
 
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
+class GradleVersionsFilterPluginTest {
 
-class GradleVersionsFilterPluginTest{
-
-    //var qualifiers: List<String> = listOf("beta")
     @Test
-    fun applyPlugin(){
+    fun applyPlugin() {
         val project = ProjectBuilder.builder().build()
         project.pluginManager.apply(GradleVersionsFilterPlugin::class.java)
 
-       assertNotNull(project.plugins.getPlugin(GradleVersionsFilterPlugin::class.java))
+        assertNotNull(project.plugins.getPlugin(GradleVersionsFilterPlugin::class.java))
     }
 
     /* To-do: write some tests for testing includes,excludes etc

--- a/src/test/resources/build.gradle.test
+++ b/src/test/resources/build.gradle.test
@@ -1,3 +1,5 @@
+import se.ascp.gradle.Strategy.INCLUSIVE
+
 plugins {
     id("java-gradle-plugin")
     id("se.ascp.gradle.gradle-versions-filter")


### PR DESCRIPTION
Use Gradle Lazy Properties to allow simpler override of defaults. Add OR strategy to allow considering both inclusive and exclusive sets.

Signed-off-by: Josef Andersson <josef.andersson@gmail.com>